### PR TITLE
Logging and configurable device

### DIFF
--- a/run.py
+++ b/run.py
@@ -8,11 +8,13 @@ openleadr.enable_default_logging(level=logging.DEBUG)
 VTN_URL = 'http://localhost:8000/auth-token/OpenADR2/Simple/2.0b'
 VEN_ID = 'bellawatt.example.ven.123'
 VEN_NAME = 'example-ven'
+RESOURCE_ID = 'example-device-001'
 
 parser = ArgumentParser(prog='example-ven', description='Arguments for running the Example Ven')
 parser.add_argument('-v', '--ven-id', type=str, default=VEN_ID, help='Your ven-id')
 parser.add_argument('-u', '--vtn-url', type=str, default=VTN_URL, help='The url of the vtn you will be connecting to')
 parser.add_argument('-n', '--ven-name', type=str, default=VEN_NAME, help='The name of your ven')
+parser.add_argument('-r', '--resource-id', type=str, default=RESOURCE_ID, help='An ID for your device (known as resource in openADR)')
 
 args = parser.parse_args()
 
@@ -20,6 +22,7 @@ ven = ExampleVen(
   ven_id=args.ven_id,
   ven_name=args.ven_name,
   vtn_url=args.vtn_url,
+  resource_id=args.resource_id
 )
 
 loop = get_event_loop()

--- a/run.py
+++ b/run.py
@@ -1,6 +1,9 @@
 from asyncio import get_event_loop
 from argparse import ArgumentParser
 from ven import ExampleVen
+import openleadr
+import logging
+openleadr.enable_default_logging(level=logging.DEBUG)
 
 VTN_URL = 'http://localhost:8000/auth-token/OpenADR2/Simple/2.0b'
 VEN_ID = 'bellawatt.example.ven.123'

--- a/ven.py
+++ b/ven.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 from openleadr import OpenADRClient
 from openleadr.enums import MEASUREMENTS
-from random import random
 
 class ExampleVen:
   """
@@ -9,20 +8,20 @@ class ExampleVen:
 
   Sample Payload Representations can be found here: https://openleadr.org/docs/representations.html
   """
-  def __init__(self, **kwargs):
+  def __init__(self, resource_id, **kwargs):
     self.client = OpenADRClient(**kwargs)
     self.run = self.client.run
 
-    self.register_handlers()
+    self.register_handlers(resource_id)
 
-  def register_handlers(self):
+  def register_handlers(self, resource_id):
     self.client.add_handler('on_event', self.handle_event)
 
     self.client.add_report(
       callback=self.energy_report,
       report_specifier_id='RealEnergy',
       measurement=MEASUREMENTS.REAL_ENERGY,
-      resource_id='example-device-001',
+      resource_id=resource_id,
       sampling_rate=timedelta(hours=1),
     )
 
@@ -30,11 +29,11 @@ class ExampleVen:
       callback=self.status_report,
       report_specifier_id='Status',
       report_name='TELEMETRY_STATUS',
-      resource_id='example-device-001',
+      resource_id=resource_id,
       sampling_rate=timedelta(seconds=30),
     )
 
-  
+
   @staticmethod
   async def handle_event(event):
     print('Just received an event!', event)
@@ -45,7 +44,7 @@ class ExampleVen:
           print(f'Start: {interval["dtstart"].isoformat()}')
           print(f'Duration: {interval["duration"].seconds}')
           print(f'Price: {interval["signal_payload"]}')
-    
+
     return 'optIn'
 
   @staticmethod
@@ -58,7 +57,7 @@ class ExampleVen:
     See more here: https://openleadr.org/docs/reporting.html
     """
     return random()
-  
+
   @staticmethod
   async def status_report():
     """


### PR DESCRIPTION
Two changes:

1. Use debug level logging for OpenLEADR
2. Allow a user to pass in a resource_id as a command line argument when starting the VEN